### PR TITLE
feat(note schema): add `uuid` property to v2/note schema

### DIFF
--- a/src/JsonSchema/v2/note.json
+++ b/src/JsonSchema/v2/note.json
@@ -7,7 +7,7 @@
   },
   "title": "Representation of a Note Object",
   "type": "object",
-  "required": ["uuid", "title", "content"],
+  "required": ["title", "content"],
   "additionalProperties": false,
   "properties": {
     "uuid": {

--- a/src/JsonSchema/v2/note.json
+++ b/src/JsonSchema/v2/note.json
@@ -7,9 +7,14 @@
   },
   "title": "Representation of a Note Object",
   "type": "object",
-  "required": ["title", "content"],
+  "required": ["uuid", "title", "content"],
   "additionalProperties": false,
   "properties": {
+    "uuid": {
+      "type": ["string", "null"],
+      "format": "uuid",
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+    },
     "title": {
       "type": "string"
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add missing `uuid` property

## Motivation and context

The `uuid` field is part of the entity's properties.

## How has this been tested?

not really, but I own this repo, so I'm self-testing post merge
